### PR TITLE
Rename Core Team and Community Manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 .Ruserdata
 /.quarto/
 _site
+*.html
+site_libs

--- a/governance.qmd
+++ b/governance.qmd
@@ -1,5 +1,8 @@
 ---
 title: "Governance"
+format:
+  html:
+    toc: true
 ---
 
 <!-- 
@@ -12,12 +15,93 @@ and is licensed under CC-BY-SA-4.0
 -->
 
 The R4DS Online Learning Community ("R4DS") comprises the [R4DS Slack community](https://r4ds.io/join), and the repositories under the [r4ds GitHub organization](https://github.com/r4ds) and the [rfordatascience Github organization](https://github.com/rfordatascience) (and the packages, websites, and data pipelines that those repositories represent).
-It has a large community of __learners__, __mentors__, and __facilitators__, a team of __administrators__, a __Core Team__, and a __Community Manager__. 
+It has a large community of __learners__, __mentors__, and __facilitators__, a team of __administrators__, a __Board of Directors__, and an __Executive Director__. 
 This document details how the project is governed and what the various responsibilities 
 are for each role in the community.
 
-TLDR: The R4DS Core Team (led by the Community Manager) leads the strategy, development, and maintenance of the 
-project and actively welcomes engagement from the community of learners, mentors, and facilitators.
+TLDR: The R4DS __Board of Directors__ (led by the __Executive Director__) leads the strategy, development, and maintenance of R4DS and actively welcomes engagement from the community of learners, mentors, and facilitators.
+
+## Board of Directors
+
+The Board of Directors of the R4DS Online Learning Community is:
+
+- [Jon Harmon](https://github.com/jonthegeek)
+- [Tan Ho](https://github.com/tanho63)
+- [Lydia Gibson](https://github.com/lgibson7)
+
+Board of Directors members are collectively responsible for governance of the R4DS Online Learning Community. Governance activities include:
+
+- Ensuring the long term viability of the R4DS;
+- Deciding on organization-wide policies, procedures, and issues;
+- Dealing with issues related to the [code of conduct](code_of_conduct.html);
+- Approving R4DS expenses;
+- Any other decisions that impact the community as a whole.
+
+An invitation to join the Board of Directors can be extended to anyone who has shown interest and aptitude in furthering the goals of the R4DS Online Learning Community.
+Any existing Board of Directors member can contact the Executive Director to recommend that a member of the Community be invited to the Board of Directors. 
+If the Executive Director approves of the nomination, they will put the member forward to the rest of the Board of Directors for a simple-majority vote.
+
+All Board of Directors members are bound by the [code of conduct](code_of_conduct.html).
+
+If a member of the Board of Directors no longer wishes to be a member of the Board of Directors, they may retire from the Board of Directors by informing the Executive Director.
+If a member of the Board of Directors becomes inactive or no longer reflects the values of the Community, they may be removed from the Board of Directors by a two-thirds majority vote of the Board of Directors members.
+
+## Executive Director
+
+[Jon Harmon](https://github.com/jonthegeek) is the Executive Director.
+
+The Executive Director is a single individual, elected by the Board of Directors. 
+Once someone has been appointed Executive Director, they remain in that role until they choose to retire, or the Board of Directors casts a two-thirds majority vote to remove them.
+
+The Executive Director is responsible for coordinating and facilitating communications within the Board of Directors and between the Board of Directors and third parties. 
+Where required and with the consent of the Board of Directors, the Executive Director may act on behalf of the Board of Directors and the R4DS Online Learning Community.
+
+The Executive Director has no additional authority over other members of the Board of Directors; the role is one of coordinator and facilitator. 
+The Executive Director is also expected to ensure that all governance processes are adhered to, and has the deciding vote in the event an action does not receive consensus among the Board of Directors.
+
+The Executive Director is bound by the [code of conduct](code_of_conduct.html).
+
+## Administrators
+
+Administrators help to manage the R4DS Slack and/or GitHub repositories.
+Common administrator activities may include (in addition to those of a learner, mentor, and/or facilitator):
+
+- Approving and merging pull requests;
+- Deleting spam messages;
+- Removing learners who violate the [code of conduct](code_of_conduct.html);
+- Approving or denying Slack app requests.
+
+Currently, all administrators are also members of the Board of Directors, and are added through the same process.
+
+## Facilitators
+
+Facilitators are learners who help organize and run R4DS book clubs.
+Common facilitator activities may include (in addition to those of a learner):
+
+- Introducing new book clubs (and presenting the first chapter);
+- Ensuring that someone is signed up to present each week;
+- Reminding club members about meeting times;
+- Informing administrators of any requested changes in the book club schedule;
+- Helping to maintain the book club slide repository;
+- Informing administrators of any issues that need to be escalated.
+
+Facilitators must have participated in at least one previous book club, and must have lead the discussion at least once.
+Facilitators are *not* expected to be experts in the book nor its subject; they are members of the club just like any other learner.
+
+## Mentors
+
+Mentors are learners who answer questions on the R4DS Slack.
+Common mentor activities may include (in addition to those of a learner):
+
+- Answering questions on the R4DS Slack;
+- Helping tag questions on the R4DS Slack with the R4DS emoji vocabulary;
+- Holding semi-official office hours to answer questions in a structured format;
+- Welcoming new users to the R4DS Slack.
+
+Anyone can become a mentor: there is no expectation of commitment to the project, 
+no required skillset, and no selection process. 
+The only obligation is to follow the [code of conduct](code_of_conduct.html).
+Mentors who continue to engage with the project are added to the private #mentors_chat channel for further tips and discussion, but they are under no obligation to continue to answer questions. 
 
 ## Learners
 
@@ -36,89 +120,7 @@ Common learner activities include (but are not limited to):
 Learners who continue to engage with the project and its community will often find themselves becoming more and more involved. 
 Such learners may then go on to become mentors and/or facilitators, as described below.
 
-## Mentors
-
-Mentors are learners who answer questions on the R4DS Slack.
-Common mentor activities may include (in addition to those of a learner):
-
-- Answering questions on the R4DS Slack;
-- Helping tag questions on the R4DS Slack with the R4DS emoji vocabulary;
-- Holding semi-official office hours to answer questions in a structured format;
-- Welcoming new users to the R4DS Slack.
-
-Anyone can become a mentor: there is no expectation of commitment to the project, 
-no required skillset, and no selection process. 
-The only obligation is to follow the [code of conduct](code_of_conduct.html).
-Mentors who continue to engage with the project are added to the private #mentors_chat channel for further tips and discussion, but they are under no obligation to continue to answer questions. 
-
-## Facilitators
-
-Facilitators are learners who help organize and run R4DS book clubs.
-Common facilitator activities may include (in addition to those of a learner):
-
-- Introducing new book clubs (and presenting the first chapter);
-- Ensuring that someone is signed up to present each week;
-- Reminding club members about meeting times;
-- Informing administrators of any changes in the book club schedule;
-- Helping to maintain the book club slide repository;
-- Informing administrators of any issues that need to be escalated.
-
-Facilitators must have participated in at least one previous book club, and must have lead the discussion at least once.
-Facilitators are *not* expected to be experts in the book; they are members of the club just like any other learner.
-
-## Administrators
-
-Administrators help to manage the R4DS Slack and/or GitHub repositories.
-Common administrator activities may include (in addition to those of a learner, mentor, and/or facilitator):
-
-- Approving and merging pull requests;
-- Deleting spam messages;
-- Removing learners who violate the [code of conduct](code_of_conduct.html);
-- Approving or denying Slack app requests.
-
-Currently, all administrators are also members of the Core Team (see below), and are added through the same process.
-
-## Core Team
-
-The Core Team of the R4DS Online Learning Community are:
-
-- [Jon Harmon](https://github.com/jonthegeek)
-- [Tan Ho](https://github.com/tanho63)
-- [Lydia Gibson](https://github.com/lgibson7)
-
-Core Team members are collectively responsible for governance of the R4DS Online Learning Community. Governance activities include:
-
-- Ensuring the long term viability of the R4DS;
-- Deciding on organization-wide policies, procedures, and issues;
-- Dealing with issues related to the [code of conduct](code_of_conduct.html);
-- Approving R4DS expenses;
-- Any other decisions that impact the community as a whole.
-
-Core Team members are recruited from mentors and facilitators. 
-An invitation to join the Core Team can be extended to anyone who has shown interest and aptitude in furthering the goals of the R4DS Online Learning Community.
-Any existing Core Team member can recommend a mentor or facilitator be invited to the Core Team by messaging the Community Manager. 
-If the Community Manager approves of the nomination, they will put the member forward to the rest of the Core Team for a simple-majority vote.
-
-All Core Team members are bound by the [code of conduct](code_of_conduct.html).
-
-If a member of the Core Team no longer wishes to be a member of the Core Team, they may retire from the Core Team by informing the Community Manager.
-If a member of the Core Team becomes inactive or no longer reflects the values of the Community, they may be removed from the Core Team by a two-thirds majority vote of the Core Team members.
-
-## Community Manager
-
-[Jon Harmon](https://github.com/jonthegeek) is the Community Manager.
-
-The Community Manager is a single individual, elected by the Core Team. 
-Once someone has been appointed Community Manager, they remain in that role until they choose to retire, or the Core Team casts a two-thirds majority vote to remove them.
-
-The Community Manager is responsible for coordinating and facilitating communications within the Core Team and between the Core Team and third parties. 
-Where required and with the Core Team’s consent, the Community Manager may act on behalf of the Core Team and the R4DS Online Learning Community.
-
-The Community Manager has no additional authority over other members of the Core Team: the role is one of coordinator and facilitator. 
-The Community Manager is also expected to ensure that all governance processes are adhered to, and has the deciding vote in the event an action does not receive consensus among the Core Team.
-
-The Community Manager is bound by the [code of conduct](code_of_conduct.html).
-
 # Changelog
 2023-09-11: v1.0
 2023-09-29: v1.0.1 - Added Lydia Gibson to Core Team and clarified election and removal of Core Team members.
+2024-01-15: v1.1 - Renamed "Core Team" to "Board of Directors" and "Community Manager" to "Executive Director". Clarified wording of responsibilities.


### PR DESCRIPTION
Also reordered the governance doc to put the actual governance bits at the top, and added a TOC. The reorder makes this change look far more elaborate than it is.