### PR TITLE
(temporarily) remove donation links.

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -20,7 +20,7 @@ website:
     left:
       - href: bookclubs.qmd
       - href: question_answering.qmd
-      - href: donate.qmd
+      # - href: donate.qmd
       - text: About Us
         menu:
         - href: about.qmd

--- a/donate.qmd
+++ b/donate.qmd
@@ -2,35 +2,6 @@
 title: "Donate"
 ---
 
-**TL;DR:**
-
--   **If you have the means to support data science education, [please donate before March 15](https://r4ds.io/donate)!**
-
-Last September, this Community became a fiscally sponsored collective within the [Open Collective Foundation (OCF)](https://opencollective.foundation/), a 501(c)(3) charitable organization. 
-Last week, the Open Collective Foundation made the shocking announcement that [they are dissolving](https://blog.opencollective.com/open-collective-official-statement-ocf-dissolution/), which means **we have less than two weeks to [collect donations](https://r4ds.io/donate) for the foreseeable future.** 
-After March 15, we won't be able to accept donations until we are able to find a new sponsoring charity.
-
-Before we joined OCF, I paid for everything myself – our Zoom accounts, our domain names, experiments with other services like Zapier and IFTTT, even a posit::conf(2023) workshop to learn tips and tricks for managing large, open-source projects. 
-I wanted to see what this Community could become, so I made the necessary investments.
-
-I am extremely grateful to those of you who have been able to donate already. 
-With the tax-deductible donations we've received as a member of OCF, I’ve managed to pay for web services, but the existing donations will not cover our infrastructure forever. 
-Moreover, this Community needs more than web services to operate. 
-I volunteer about 20 hours per week to keep this Community running, but that unpaid labor is not sustainable, especially for this Community to continue to grow and evolve.
-
-We have plans to keep evolving:
-
--   We would love to offer additional [book clubs](bookclubs.html), to streamline the process for starting a new club, and to improve the materials used by those clubs. 
--   We would love to learn more about who uses [TidyTuesday](https://tidytues.day/) datasets and what they do with the data, and to make it easier for them to work with that data. 
--   We would love to continue to provide a friendly place for people to [help one another with their data science questions](question_answering.html), and to expand to additional data-related topics and languages.
--   And we would love to offer mentorship and career services to help data science learners become data science professionals.
-
-By design, most of our active members are just starting out on their data science journeys. 
-They cannot afford an expensive data science education, and they do not have the means to make a donation. 
-That's a big part of why we exist. 
-
-[As Jeff Leek noted in his rstudio::conf(2022) keynote](https://www.youtube.com/watch?v=Vf301YCxP1Q), "Mentorship is a debt you don't pay off, you pay it forward." 
-For those of you who are further along in your data science careers, I ask that you [help us continue to provide free data science education by donating today](https://r4ds.io/donate). 
-
-Thank you,<br>
-Jon Harmon (jonthegeek)
+*We are unable to accept donations until we find a new fiscal host.*
+*Thank you for your interest in helping!*
+*If you have information about a fiscal host that you believe we should look into, please [contact us](mailto:rfordatasci@gmail.com).*

--- a/sponsor.qmd
+++ b/sponsor.qmd
@@ -2,35 +2,6 @@
 title: "Sponsorship"
 ---
 
-**TL;DR:**
-
--   **If you have the means to support data science education, [please donate before March 15](https://r4ds.io/donate)!**
-
-Last September, this Community became a fiscally sponsored collective within the [Open Collective Foundation (OCF)](https://opencollective.foundation/), a 501(c)(3) charitable organization. 
-Last week, the Open Collective Foundation made the shocking announcement that [they are dissolving](https://blog.opencollective.com/open-collective-official-statement-ocf-dissolution/), which means **we have less than two weeks to [collect donations](https://r4ds.io/donate) for the foreseeable future.** 
-After March 15, we won't be able to accept donations until we are able to find a new sponsoring charity.
-
-Before we joined OCF, I paid for everything myself – our Zoom accounts, our domain names, experiments with other services like Zapier and IFTTT, even a posit::conf(2023) workshop to learn tips and tricks for managing large, open-source projects. 
-I wanted to see what this Community could become, so I made the necessary investments.
-
-I am extremely grateful to those of you who have been able to donate already. 
-With the tax-deductible donations we've received as a member of OCF, I’ve managed to pay for web services, but the existing donations will not cover our infrastructure forever. 
-Moreover, this Community needs more than web services to operate. 
-I volunteer about 20 hours per week to keep this Community running, but that unpaid labor is not sustainable, especially for this Community to continue to grow and evolve.
-
-We have plans to keep evolving:
-
--   We would love to offer additional [book clubs](bookclubs.html), to streamline the process for starting a new club, and to improve the materials used by those clubs. 
--   We would love to learn more about who uses [TidyTuesday](https://tidytues.day/) datasets and what they do with the data, and to make it easier for them to work with that data. 
--   We would love to continue to provide a friendly place for people to [help one another with their data science questions](question_answering.html), and to expand to additional data-related topics and languages.
--   And we would love to offer mentorship and career services to help data science learners become data science professionals.
-
-By design, most of our active members are just starting out on their data science journeys. 
-They cannot afford an expensive data science education, and they do not have the means to make a donation. 
-That's a big part of why we exist. 
-
-[As Jeff Leek noted in his rstudio::conf(2022) keynote](https://www.youtube.com/watch?v=Vf301YCxP1Q), "Mentorship is a debt you don't pay off, you pay it forward." 
-For those of you who are further along in your data science careers, I ask that you [help us continue to provide free data science education by donating today](https://r4ds.io/donate). 
-
-Thank you,<br>
-Jon Harmon (jonthegeek)
+*We are unable to accept donations until we find a new fiscal host.*
+*Thank you for your interest in helping!*
+*If you have information about a fiscal host that you believe we should look into, please [contact us](mailto:rfordatasci@gmail.com).*


### PR DESCRIPTION
These URLs are still out there, so I don't want to delete the pages, but let's remove it from the main page, and let's not send people to our broken donation page.

The redirects will point to the donate.html page (after an update in the r4ds/r4ds.io repo).